### PR TITLE
Fix typo in source.xml

### DIFF
--- a/source/source.xml
+++ b/source/source.xml
@@ -378,7 +378,7 @@ myproject/
         <title>XSLT</title>
         <itemizedlist>
           <listitem>
-            <para>Avoid too many nested <code>xsl:choose</code> as this will make your code difficult do decipher. Try
+            <para>Avoid too many nested <code>xsl:choose</code> as this will make your code difficult to decipher. Try
               to replace with <code>xsl:template</code> with concrete matching patterns.</para>
           </listitem>
           <listitem>


### PR DESCRIPTION
I noticed a typo in https://transpect.github.io/styleguide.html and traced it to this file.